### PR TITLE
Adjust GitHub Actions trigger settings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish Package
 
 on:
   release:
-    types: [ published ]
+    types: [ published, edited ]
 
 permissions:
   contents: read


### PR DESCRIPTION
This commit modifies the 'on' trigger in the publish.yml GitHub Actions workflow. The changes allow the workflow to trigger not only when a release is published, but also when it is edited. This is to ensure all changes in a release are captured and published correctly.