### PR TITLE
Update codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
 
       - run: poetry install
       - run: poetry run pytest --cov=pandas_pyarrow --cov-report=xml
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+#          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
     continue-on-error: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Codecov
 on:
   pull_request:
     paths:
@@ -9,7 +9,7 @@ on:
       - 'poetry.lock'
   workflow_dispatch:
 jobs:
-  tests:
+  upload-coverage-report:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,9 +21,10 @@ jobs:
 
       - run: poetry install
       - run: poetry run pytest --cov=pandas_pyarrow --cov-report=xml
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
-#          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     continue-on-error: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -10,19 +10,20 @@ on:
   workflow_dispatch:
 jobs:
   tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: pipx install poetry
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.11'
           cache: poetry
 
       - run: poetry install
-      - run: poetry run pytest
+      - run: poetry run pytest --cov=pandas_pyarrow --cov-report=xml
+      - uses: codecov/codecov-action@v3
+        with:
+#          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true
     continue-on-error: true


### PR DESCRIPTION
The commit updates codecov-action from version 2 to version 3 in the continuous integration workflow. It also comments out the token used for codecov resulting in no token being passed. This may have implications on the codecov reporting and needs to be reviewed.