### PR TITLE
Add support for converting pyarrow DataFrame to numpy

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,9 +4,8 @@ on:
     paths:
       - 'pandas_pyarrow/**'
       - 'tests/**'
-      - '.github/workflows/ci.yml'
-      - 'pyproject.toml'
-      - 'poetry.lock'
+      - '.github/workflows/codecov.yml'
+
   workflow_dispatch:
 jobs:
   upload-coverage-report:

--- a/pandas_pyarrow/__init__.py
+++ b/pandas_pyarrow/__init__.py
@@ -1,7 +1,9 @@
 from importlib.metadata import version
 
 from .pda_converter import PandasArrowConverter
+from .reverse_converter import convert_to_numpy
 
 __version__ = version("pandas-pyarrow")
+
 convert_to_pyarrow = PandasArrowConverter()
-__all__ = ["PandasArrowConverter", "convert_to_pyarrow"]
+__all__ = ["PandasArrowConverter", "convert_to_pyarrow", "convert_to_numpy"]

--- a/pandas_pyarrow/reverse_converter.py
+++ b/pandas_pyarrow/reverse_converter.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+
+def convert_to_numpy(df: pd.DataFrame) -> pd.DataFrame:
+    cols = df.columns
+    dtypes = df.dtypes
+    df_ = df.copy()
+    for col, dtype in zip(cols, dtypes):
+        if repr(dtype).startswith("timestamp"):
+            dt_format = "[" + repr(dtype).split("[")[1]
+            df_[col] = df_[col].values.astype(f"datetime64{dt_format}")
+        elif repr(dtype) == "halffloat[pyarrow]":
+            df_[col] = df_[col].values.astype("float16")
+        elif repr(dtype).startswith("duration"):
+            td_format = "[" + repr(dtype).split("[")[1]
+            df_[col] = df_[col].values.astype(f"timedelta64{td_format}")
+    return df_.convert_dtypes()

--- a/pandas_pyarrow/reverse_converter.py
+++ b/pandas_pyarrow/reverse_converter.py
@@ -14,4 +14,6 @@ def convert_to_numpy(df: pd.DataFrame) -> pd.DataFrame:
         elif repr(dtype).startswith("duration"):
             td_format = "[" + repr(dtype).split("[")[1]
             df_[col] = df_[col].values.astype(f"timedelta64{td_format}")
+        elif repr(dtype).startswith("string"):
+            df_[col] = df_[col].values.astype("object")
     return df_.convert_dtypes()

--- a/tests/unit/property_based/test_general.py
+++ b/tests/unit/property_based/test_general.py
@@ -1,5 +1,4 @@
-from pandas_pyarrow import convert_to_pyarrow
-from pandas_pyarrow.reverse_converter import convert_to_numpy
+from pandas_pyarrow import convert_to_numpy, convert_to_pyarrow
 from tests.unit.property_based.pb_sts import COMMON_DTYPES_SAMPLE, UNCOMMON_DTYPES_SAMPLE, df_st
 
 import hypothesis as hp

--- a/tests/unit/property_based/test_general.py
+++ b/tests/unit/property_based/test_general.py
@@ -1,4 +1,5 @@
 from pandas_pyarrow import convert_to_pyarrow
+from pandas_pyarrow.reverse_converter import convert_to_numpy
 from tests.unit.property_based.pb_sts import COMMON_DTYPES_SAMPLE, UNCOMMON_DTYPES_SAMPLE, df_st
 
 import hypothesis as hp
@@ -22,3 +23,12 @@ def test_common_dtypes_hp(df):
     adf_pd_api = df.convert_dtypes(dtype_backend="pyarrow")
     adf = convert_to_pyarrow(df)
     assert adf_pd_api.compare(adf).empty, "The conversion is not consistent with pandas api"
+
+
+@hp.given(df=df_st(dtypes=COMMON_DTYPES_SAMPLE + UNCOMMON_DTYPES_SAMPLE))
+def test_convert_to_numpy(df):
+    adf = convert_to_pyarrow(df)
+    rdf = convert_to_numpy(adf)
+    new_numpy_dtypes = [repr(i) for i in rdf.dtypes.tolist()]
+    is_numpy = ["[pyarrow]" not in dtype for dtype in new_numpy_dtypes]
+    assert all(is_numpy), "Some dtypes are not converted to numpy"

--- a/tests/unit/property_based/test_general.py
+++ b/tests/unit/property_based/test_general.py
@@ -26,8 +26,11 @@ def test_common_dtypes_hp(df):
 
 @hp.given(df=df_st(dtypes=COMMON_DTYPES_SAMPLE + UNCOMMON_DTYPES_SAMPLE))
 def test_convert_to_numpy(df):
+    df_copy = df.copy()
     adf = convert_to_pyarrow(df)
     rdf = convert_to_numpy(adf)
     new_numpy_dtypes = [repr(i) for i in rdf.dtypes.tolist()]
     is_numpy = ["[pyarrow]" not in dtype for dtype in new_numpy_dtypes]
     assert all(is_numpy), "Some dtypes are not converted to numpy"
+    assert rdf.equals(convert_to_numpy(rdf)), "The conversion is not idempotent"
+    assert df_copy.equals(df), "The original df has been modified"

--- a/tests/unit/test_reverse_converter.py
+++ b/tests/unit/test_reverse_converter.py
@@ -1,0 +1,45 @@
+# File: test_reverse_converter.py
+from pandas_pyarrow import convert_to_numpy, convert_to_pyarrow
+
+import numpy as np
+import pandas as pd
+
+
+def test_convert_timestamp():
+    data = {
+        "timestamp_col": pd.Series(
+            pd.date_range("2000", periods=100, freq="D"),
+        )
+    }
+    df = pd.DataFrame(data)
+    adf = convert_to_pyarrow(df)
+    rdf = convert_to_numpy(adf)
+    r_dtype = rdf["timestamp_col"].dtype
+    assert "pyarrow" not in repr(r_dtype)
+
+
+def test_convert_halffloat():
+    data = {"halffloat_col": pd.Series(np.random.rand(100), dtype="float16")}
+    df = pd.DataFrame(data)
+    adf = convert_to_pyarrow(df)
+    rdf = convert_to_numpy(adf)
+    r_dtype = rdf["halffloat_col"].dtype
+    assert "pyarrow" not in repr(r_dtype)
+
+
+def test_convert_duration():
+    data = {"duration_col": pd.Series(pd.to_timedelta(np.arange(100), "D"), dtype="timedelta64[ns]")}
+    df = pd.DataFrame(data)
+    adf = convert_to_pyarrow(df)
+    rdf = convert_to_numpy(adf)
+    r_dtype = rdf["duration_col"].dtype
+    assert r_dtype == "timedelta64[ns]"
+
+
+def test_convert_string():
+    data = {"string_col": pd.Series(["abc", "def", "ghi"], dtype="object")}
+    df = pd.DataFrame(data)
+    adf = convert_to_pyarrow(df)
+    rdf = convert_to_numpy(adf)
+    r_dtype = rdf["string_col"].dtype
+    assert repr(r_dtype) == "string[python]"


### PR DESCRIPTION
Introduced a new function `convert_to_numpy` to reverse convert pyarrow DataFrame to numpy dtypes. Added a unit test to ensure the conversions are accurate and consistent with expected numpy dtypes.