### PR TITLE
Add GitHub workflow for auto-merging Dependabot PRs

### DIFF
--- a/.github/workflows/auto_merge_dependabot_prs.yml
+++ b/.github/workflows/auto_merge_dependabot_prs.yml
@@ -1,0 +1,25 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up GitHub CLI
+        uses: actions/setup-gh-cli@v1
+
+      - name: Auto-merge Dependabot PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ github.event.pull_request.number }} --auto --squash

--- a/.github/workflows/auto_merge_dependabot_prs.yml
+++ b/.github/workflows/auto_merge_dependabot_prs.yml
@@ -6,11 +6,12 @@ on:
       - opened
       - synchronize
       - reopened
+      - completed
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]' && github.event.check_suite.conclusion == 'success'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -23,3 +24,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr merge ${{ github.event.pull_request.number }} --auto --squash
+
+  open-issue-on-failure:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && github.event.check_suite.conclusion != 'success'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up GitHub CLI
+        uses: actions/setup-gh-cli@v1
+
+      - name: Open issue for failed Dependabot PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create --title "Dependabot PR #${{ github.event.pull_request.number }} checks failed" --body "The checks for Dependabot PR #${{ github.event.pull_request.number }} have failed. Please review and resolve the issues."


### PR DESCRIPTION
This new workflow triggers on pull request events and auto-merges Dependabot PRs using GitHub CLI. It ensures that Dependabot updates are seamlessly integrated into the codebase without manual intervention.