### PR TITLE
Update auto-merge workflow trigger and condition

### DIFF
--- a/.github/workflows/auto_merge_dependabot_prs.yml
+++ b/.github/workflows/auto_merge_dependabot_prs.yml
@@ -1,17 +1,14 @@
 name: Auto-merge Dependabot PRs
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - completed
+  check_suite:
+    types: [completed]
 
 jobs:
   auto-merge:
+
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && github.event.check_suite.conclusion == 'success'
+    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Change the event trigger to 'check_suite' and remove the 'check_suite.conclusion' condition in the auto-merge job. This streamlines the workflow by making it responsive to completed check suites and simplifies the merge condition.