### PR TITLE
Update event trigger for dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,6 +1,8 @@
 # Based on https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
 name: Dependabot auto-merge
-on: pull_request_target
+on:
+  check_suite:
+    types: [completed]
 
 permissions:
     pull-requests: write


### PR DESCRIPTION
Changed the trigger for the dependabot auto-merge workflow from `pull_request_target` to `check_suite` with `types: [completed]`. This ensures the workflow runs only after the check suite is complete.