### PR TITLE
Update event trigger in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,7 +1,7 @@
 # Based on https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
 name: Dependabot auto-merge
 on:
-  check_suite:
+  check_run:
     types: [completed]
 
 permissions:


### PR DESCRIPTION
Changed the event trigger from check_suite to check_run for Dependabot auto-merge. This adjustment ensures the workflow runs whenever any check completes, rather than waiting for an entire suite, leading to more immediate auto-merge actions.