### PR TITLE
Update auto-merge trigger to pull_request_target

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,8 +1,6 @@
 # Based on https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
 name: Dependabot auto-merge
-on:
-  check_run:
-    types: [completed]
+on: pull_request_target
 
 permissions:
     pull-requests: write


### PR DESCRIPTION
Changed the GitHub Actions workflow to trigger on pull_request_target instead of check_run. This adjustment ensures more precise handling of pull requests, improving the automation of the auto-merge process for dependabot updates.